### PR TITLE
Updating due to #3 and Terraform v0.11.7

### DIFF
--- a/private.tf
+++ b/private.tf
@@ -4,7 +4,7 @@ locals {
 }
 
 module "private_label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.0"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.1"
   namespace  = "${var.namespace}"
   name       = "${var.name}"
   stage      = "${var.stage}"

--- a/private.tf
+++ b/private.tf
@@ -1,6 +1,6 @@
 locals {
   private_count       = "${var.enabled == "true" && var.type == "private" ? length(var.availability_zones) : 0}"
-  private_route_count = "${var.enabled == "true" && var.type == "private" ? length(var.az_ngw_count) : 0}"
+  private_route_count = "${var.enabled == "true" && var.type == "private" && var.nat_gateway_enabled == "true" ? length(var.az_ngw_count) : 0}"
 }
 
 module "private_label" {

--- a/public.tf
+++ b/public.tf
@@ -4,7 +4,7 @@ locals {
 }
 
 module "public_label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.0"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.1"
   namespace  = "${var.namespace}"
   name       = "${var.name}"
   stage      = "${var.stage}"


### PR DESCRIPTION
Current version breaks with nat_gateway=false and Terraform v0.11.7.  Output is:

```
Error: module.private_subnets.aws_route.default: 1 error(s) occurred:

* module.private_subnets.aws_route.default: element: element() may not be used with an empty list in:

${lookup(var.az_ngw_ids, element(keys(var.az_ngw_ids), count.index))}
```

Setting `az_ngw_count = 0` did not work (though I don't see why it wouldn't).  The only way to solve was to update the `local.private_route_count` and ensure it's 0
