### PR TITLE
Relax AWS provider to permit 2.x and 3.x releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Available targets:
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0 |
-| aws | >= 2.0 |
+| aws | >= 2.0, < 4.0 |
 | local | >= 1.2 |
 | null | >= 2.0 |
 | template | >= 2.0 |
@@ -222,7 +222,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.0 |
+| aws | >= 2.0, < 4.0 |
 
 ## Inputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,7 +4,7 @@
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0 |
-| aws | >= 2.0 |
+| aws | >= 2.0, < 4.0 |
 | local | >= 1.2 |
 | null | >= 2.0 |
 | template | >= 2.0 |
@@ -13,7 +13,7 @@
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.0 |
+| aws | >= 2.0, < 4.0 |
 
 ## Inputs
 

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0"
 
   required_providers {
-    aws      = ">= 2.0"
+    aws      = ">= 2.0, < 4.0"
     template = ">= 2.0"
     local    = ">= 1.2"
     null     = ">= 2.0"


### PR DESCRIPTION
## what
* Relaxes the version pinning on the module to allow the existing 2.x and now newer 3.x AWS provider to be used

## why
* To allow code that calls this module _and_ requires newer resources that only exist in the 3.x provider to co-exist

## references
* https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md#300-july-31-2020 includes breaking changes, hence the version bump, but no breaking changes relate to the resources used in this module.

