### PR TITLE
use minimum versions for provider pinning

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,21 +207,22 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 2.0 |
-| local | ~> 1.2 |
-| null | ~> 2.0 |
-| template | ~> 2.0 |
+| terraform | >= 0.12.0 |
+| aws | >= 2.0 |
+| local | >= 1.2 |
+| null | >= 2.0 |
+| template | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | >= 2.0 |
 
 ## Inputs
 
@@ -258,6 +259,7 @@ Available targets:
 | az\_subnet\_arns | Map of AZ names to subnet ARNs |
 | az\_subnet\_ids | Map of AZ names to subnet IDs |
 
+<!-- markdownlint-restore -->
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,18 +1,19 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 2.0 |
-| local | ~> 1.2 |
-| null | ~> 2.0 |
-| template | ~> 2.0 |
+| terraform | >= 0.12.0 |
+| aws | >= 2.0 |
+| local | >= 1.2 |
+| null | >= 2.0 |
+| template | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | >= 2.0 |
 
 ## Inputs
 
@@ -49,3 +50,4 @@
 | az\_subnet\_arns | Map of AZ names to subnet ARNs |
 | az\_subnet\_ids | Map of AZ names to subnet IDs |
 
+<!-- markdownlint-restore -->

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.0, < 0.14.0"
+  required_version = ">= 0.12.0"
 
   required_providers {
     aws      = ">= 2.0"

--- a/versions.tf
+++ b/versions.tf
@@ -2,9 +2,9 @@ terraform {
   required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
-    aws      = "~> 2.0"
-    template = "~> 2.0"
-    local    = "~> 1.2"
-    null     = "~> 2.0"
+    aws      = ">= 2.0"
+    template = ">= 2.0"
+    local    = ">= 1.2"
+    null     = ">= 2.0"
   }
 }


### PR DESCRIPTION
## what
set minimum versions for providers without pinning to a specific major version



## why
the current method makes it very difficult to maintain or upgrade consistent provider versions within a project



## references
https://www.terraform.io/docs/configuration/provider-requirements.html#best-practices-for-provider-versions



