### PR TITLE
Fix nat_gateway_enabled=false Invalid index error

### DIFF
--- a/examples/complete/fixtures.nat_gw_disabled.tfvars
+++ b/examples/complete/fixtures.nat_gw_disabled.tfvars
@@ -1,0 +1,1 @@
+nat_gateway_enabled = "false"

--- a/examples/complete/fixtures.nat_gw_enabled.tfvars
+++ b/examples/complete/fixtures.nat_gw_enabled.tfvars
@@ -1,0 +1,1 @@
+nat_gateway_enabled = "true"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -25,7 +25,7 @@ module "public_subnets" {
   cidr_block          = local.public_cidr_block
   type                = "public"
   igw_id              = module.vpc.igw_id
-  nat_gateway_enabled = true
+  nat_gateway_enabled = var.nat_gateway_enabled
 
   context = module.this.context
 }

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -12,3 +12,7 @@ variable "availability_zones" {
   type        = list(string)
   description = "List of Availability Zones (e.g. `['us-east-1a', 'us-east-1b', 'us-east-1c']`)"
 }
+
+variable "nat_gateway_enabled" {
+  description = "Flag to enable/disable NAT Gateways creation in public subnets"
+}

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,11 @@ locals {
     subnet_id      = local.public_enabled ? aws_subnet.public[az].id : aws_subnet.private[az].id
     subnet_arn     = local.public_enabled ? aws_subnet.public[az].arn : aws_subnet.private[az].arn
     route_table_id = local.public_enabled ? aws_route_table.public[az].id : aws_route_table.private[az].id
-    ngw_id         = local.nat_gateway_enabled ? try(aws_nat_gateway.public[az].id, null) : null
+    }
+  }
+  # Only relevant for public subnets. Output is empty map for private subnets or when nat gateway is disabled
+  output_ngw_id = { for az in(local.public_enabled && local.nat_gateway_enabled ? var.availability_zones : []) : az => {
+    ngw_id         = local.public_enabled ? try(aws_nat_gateway.public[az].id, null) : null
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,15 +1,16 @@
 locals {
   enabled = module.this.enabled
 
-  public_enabled     = local.enabled && var.type == "public"
-  private_enabled    = local.enabled && var.type == "private"
-  availability_zones = local.enabled ? var.availability_zones : []
+  public_enabled      = local.enabled && var.type == "public"
+  private_enabled     = local.enabled && var.type == "private"
+  availability_zones  = local.enabled ? var.availability_zones : []
+  nat_gateway_enabled = local.enabled && var.nat_gateway_enabled
 
   output_map = { for az in(local.enabled ? var.availability_zones : []) : az => {
     subnet_id      = local.public_enabled ? aws_subnet.public[az].id : aws_subnet.private[az].id
     subnet_arn     = local.public_enabled ? aws_subnet.public[az].arn : aws_subnet.private[az].arn
     route_table_id = local.public_enabled ? aws_route_table.public[az].id : aws_route_table.private[az].id
-    ngw_id         = local.public_enabled ? aws_nat_gateway.public[az].id : null
+    ngw_id         = local.nat_gateway_enabled ? try(aws_nat_gateway.public[az].id, null) : null
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ locals {
   }
   # Only relevant for public subnets. Output is empty map for private subnets or when nat gateway is disabled
   output_ngw_id = { for az in(local.public_enabled && local.nat_gateway_enabled ? var.availability_zones : []) : az => {
-    ngw_id         = local.public_enabled ? try(aws_nat_gateway.public[az].id, null) : null
+    ngw_id = local.public_enabled ? try(aws_nat_gateway.public[az].id, null) : null
     }
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,7 +15,7 @@ output "az_route_table_ids" {
 
 output "az_ngw_ids" {
   # No ellipsis needed since this module makes either public or private subnets. See the TF 0.15 one function
-  value       = { for az, m in local.output_map : az => m.ngw_id }
+  value       = { for az, m in local.output_ngw_id : az => m.ngw_id }
   description = "Map of AZ names to NAT Gateway IDs (only for public subnets)"
 }
 

--- a/private.tf
+++ b/private.tf
@@ -1,6 +1,6 @@
 locals {
   private_azs = local.private_enabled ? { for idx, az in var.availability_zones : az => idx } : {}
-  az_ngw_ids  = local.nat_gateway_enabled ? { for az, ngw_id in var.az_ngw_ids : az => ngw_id if ngw_id != null } : {}
+  az_ngw_ids  = local.nat_gateway_enabled ? var.az_ngw_ids : {}
 }
 
 module "private_label" {

--- a/private.tf
+++ b/private.tf
@@ -1,5 +1,6 @@
 locals {
   private_azs = local.private_enabled ? { for idx, az in var.availability_zones : az => idx } : {}
+  az_ngw_ids  = local.nat_gateway_enabled ? { for az, ngw_id in var.az_ngw_ids : az => ngw_id if ngw_id != null } : {}
 }
 
 module "private_label" {
@@ -90,10 +91,10 @@ resource "aws_route_table_association" "private" {
 }
 
 resource "aws_route" "default" {
-  for_each = local.private_azs
+  for_each = local.az_ngw_ids
 
   route_table_id         = aws_route_table.private[each.key].id
-  nat_gateway_id         = var.az_ngw_ids[each.key]
+  nat_gateway_id         = each.value
   destination_cidr_block = "0.0.0.0/0"
   depends_on             = [aws_route_table.private]
 }

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -105,7 +105,7 @@ func TestExamplesCompleteDisabledModule(t *testing.T) {
 		TerraformDir: "../../examples/complete",
 		Upgrade:      true,
 		// Variables to pass to our Terraform code using -var-file options
-		VarFiles: []string{"fixtures.us-east-2.tfvars", "fixtures.disabled.tfvars"},
+		VarFiles: []string{"fixtures.us-east-2.tfvars", "fixtures.nat_gw_enabled.tfvars", "fixtures.disabled.tfvars"},
 	}
 
 	// At the end of the test, run `terraform destroy` to clean up any resources that were created


### PR DESCRIPTION
## what
* Fix #44
* Same test from #45 applied and still fails
* Readded test after merge of #47 and using us-east-2 as advised
* Tried to retain the output_map AZ => null design choice when nat_gateway_enabled=false. However:-
  * I get an aws_route ExactlyOne error if the nat_gw_id is null when nat_gateway_enabled=false
  * When I filter out null ngw_ids in private.tf then I get value depends on resource attributes that cannot be determined until apply when nat_gateway_enabled=true
* Hence changed output_map AZ => null design choice to an empty map

## why
* Users should be able to create subnets without NAT gateways

## references
* closes #44
