### PR TITLE
Add cidr block output per AZ

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ Like this project? Please give it a ★ on [our GitHub](https://github.com/cloud
 Are you using this project or any of our other projects? Consider [leaving a testimonial][testimonial]. =)
 
 
+
 ## Related Projects
 
 Check out these related projects.
@@ -363,8 +364,6 @@ Check out these related projects.
 - [terraform-aws-dynamic-subnets](https://github.com/cloudposse/terraform-aws-dynamic-subnets) - Terraform module for public and private subnets provisioning in existing VPC
 - [terraform-aws-vpc](https://github.com/cloudposse/terraform-aws-vpc) - Terraform Module that defines a VPC with public/private subnets across multiple AZs with Internet Gateways
 - [terraform-aws-cloudwatch-flow-logs](https://github.com/cloudposse/terraform-aws-cloudwatch-flow-logs) - Terraform module for enabling flow logs for vpc and subnets.
-
-
 
 ## Help
 

--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ Available targets:
 | <a name="output_az_ngw_ids"></a> [az\_ngw\_ids](#output\_az\_ngw\_ids) | Map of AZ names to NAT Gateway IDs (only for public subnets) |
 | <a name="output_az_route_table_ids"></a> [az\_route\_table\_ids](#output\_az\_route\_table\_ids) | Map of AZ names to Route Table IDs |
 | <a name="output_az_subnet_arns"></a> [az\_subnet\_arns](#output\_az\_subnet\_arns) | Map of AZ names to subnet ARNs |
+| <a name="output_az_subnet_cidr_blocks"></a> [az\_subnet\_cidr\_blocks](#output\_az\_subnet\_cidr\_blocks) | Map of AZ names to subnet CIDR blocks |
 | <a name="output_az_subnet_ids"></a> [az\_subnet\_ids](#output\_az\_subnet\_ids) | Map of AZ names to subnet IDs |
 | <a name="output_az_subnet_map"></a> [az\_subnet\_map](#output\_az\_subnet\_map) | Map of AZ names to map of information about subnets |
 <!-- markdownlint-restore -->

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -80,6 +80,7 @@
 | <a name="output_az_ngw_ids"></a> [az\_ngw\_ids](#output\_az\_ngw\_ids) | Map of AZ names to NAT Gateway IDs (only for public subnets) |
 | <a name="output_az_route_table_ids"></a> [az\_route\_table\_ids](#output\_az\_route\_table\_ids) | Map of AZ names to Route Table IDs |
 | <a name="output_az_subnet_arns"></a> [az\_subnet\_arns](#output\_az\_subnet\_arns) | Map of AZ names to subnet ARNs |
+| <a name="output_az_subnet_cidr_blocks"></a> [az\_subnet\_cidr\_blocks](#output\_az\_subnet\_cidr\_blocks) | Map of AZ names to subnet CIDR blocks |
 | <a name="output_az_subnet_ids"></a> [az\_subnet\_ids](#output\_az\_subnet\_ids) | Map of AZ names to subnet IDs |
 | <a name="output_az_subnet_map"></a> [az\_subnet\_map](#output\_az\_subnet\_map) | Map of AZ names to map of information about subnets |
 <!-- markdownlint-restore -->

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -34,3 +34,10 @@ output "public_az_route_table_ids" {
   value = module.public_subnets.az_route_table_ids
 }
 
+output "private_az_subnet_cidr_blocks" {
+  value = module.private_subnets.az_subnet_cidr_blocks
+}
+
+output "public_az_subnet_cidr_blocks" {
+  value = module.public_subnets.az_subnet_cidr_blocks
+}

--- a/main.tf
+++ b/main.tf
@@ -6,10 +6,11 @@ locals {
   availability_zones = local.enabled ? var.availability_zones : []
 
   output_map = { for az in(local.enabled ? var.availability_zones : []) : az => {
-    subnet_id      = local.public_enabled ? aws_subnet.public[az].id : aws_subnet.private[az].id
-    subnet_arn     = local.public_enabled ? aws_subnet.public[az].arn : aws_subnet.private[az].arn
-    route_table_id = local.public_enabled ? aws_route_table.public[az].id : aws_route_table.private[az].id
-    ngw_id         = local.public_enabled && var.nat_gateway_enabled ? aws_nat_gateway.public[az].id : null
+    subnet_id         = local.public_enabled ? aws_subnet.public[az].id : aws_subnet.private[az].id
+    subnet_arn        = local.public_enabled ? aws_subnet.public[az].arn : aws_subnet.private[az].arn
+    route_table_id    = local.public_enabled ? aws_route_table.public[az].id : aws_route_table.private[az].id
+    ngw_id            = local.public_enabled && var.nat_gateway_enabled ? aws_nat_gateway.public[az].id : null
+    subnet_cidr_block = local.public_enabled ? aws_subnet.public[az].cidr_block : aws_subnet.private[az].cidr_block
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -8,9 +8,9 @@ locals {
   output_map = { for az in(local.enabled ? var.availability_zones : []) : az => {
     subnet_id         = local.public_enabled ? aws_subnet.public[az].id : aws_subnet.private[az].id
     subnet_arn        = local.public_enabled ? aws_subnet.public[az].arn : aws_subnet.private[az].arn
+    subnet_cidr_block = local.public_enabled ? aws_subnet.public[az].cidr_block : aws_subnet.private[az].cidr_block
     route_table_id    = local.public_enabled ? aws_route_table.public[az].id : aws_route_table.private[az].id
     ngw_id            = local.public_enabled && var.nat_gateway_enabled ? aws_nat_gateway.public[az].id : null
-    subnet_cidr_block = local.public_enabled ? aws_subnet.public[az].cidr_block : aws_subnet.private[az].cidr_block
     }
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,6 +8,11 @@ output "az_subnet_arns" {
   description = "Map of AZ names to subnet ARNs"
 }
 
+output "az_subnet_cidr_blocks" {
+  value = { for az, m in local.output_map: az => m.subnet_cidr_block }
+  description = "Map of AZ names to subnet CIDR blocks"
+}
+
 output "az_route_table_ids" {
   value       = { for az, m in local.output_map : az => m.route_table_id }
   description = " Map of AZ names to Route Table IDs"

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,7 +9,7 @@ output "az_subnet_arns" {
 }
 
 output "az_subnet_cidr_blocks" {
-  value = { for az, m in local.output_map: az => m.subnet_cidr_block }
+  value       = { for az, m in local.output_map : az => m.subnet_cidr_block }
   description = "Map of AZ names to subnet CIDR blocks"
 }
 

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -65,6 +65,11 @@ func TestExamplesComplete(t *testing.T) {
 	     "us-east-2b" = "subnet-05861d30d45e7b675"
 	     "us-east-2c" = "subnet-036d747a2b46857ae"
 	   }
+	   private_az_subnet_cidr_blocks = {
+	     "us-east-2a" = "172.16.128.0/21"
+	     "us-east-2b" = "172.16.136.0/21"
+	     "us-east-2c" = "172.16.144.0/21"
+	   }
 	   public_az_ngw_ids = {
 	     "us-east-2a" = "nat-0f5057f09b8cd8ddc"
 	     "us-east-2b" = "nat-0971b2505ea6d03f1"
@@ -79,6 +84,11 @@ func TestExamplesComplete(t *testing.T) {
 	     "us-east-2a" = "subnet-0dcb9e32f1f02a367"
 	     "us-east-2b" = "subnet-0b432a6748ca40638"
 	     "us-east-2c" = "subnet-00a9a6636ca722474"
+	   }
+	   public_az_subnet_cidr_blocks = {
+	     "us-east-2a" = "172.16.0.0/21"
+	     "us-east-2b" = "172.16.8.0/21"
+	     "us-east-2c" = "172.16.16.0/21"
 	   }
 	*/
 
@@ -110,6 +120,17 @@ func TestExamplesComplete(t *testing.T) {
 	assertValueStartsWith(t, publicRouteTableIds, "^rtb-.*")
 	assert.Equal(t, expectedAZs, getKeys(publicSubnetIds))
 	assertValueStartsWith(t, publicSubnetIds, "^subnet-.*")
+
+	expectedPublicCidrBlocks := []string{"172.16.0.0/21", "172.16.8.0/21", "172.16.16.0/21"}
+	expectedPrivateCidrBlocks := []string{"172.16.128.0/21", "172.16.136.0/21", "172.16.144.0/21"}
+	// Run `terraform output` to get the value of an output variable
+	publicSubnetCidrBlocks := terraform.OutputMap(t, terraformOptions, "public_az_subnet_cidr_blocks")
+	privateSubnetCidrBlocks := terraform.OutputMap(t, terraformOptions, "private_az_subnet_cidr_blocks")
+	// Verify output
+	assert.Equal(t, expectedAZs, getKeys(publicSubnetCidrBlocks))
+	assert.Equal(t, expectedPublicCidrBlocks, getValues(publicSubnetCidrBlocks))
+	assert.Equal(t, expectedAZs, getKeys(privateSubnetCidrBlocks))
+	assert.Equal(t, expectedPrivateCidrBlocks, getValues(privateSubnetCidrBlocks))
 }
 
 func TestExamplesCompleteDisabledModule(t *testing.T) {


### PR DESCRIPTION
## what
No resource changes at all.
Add `subnet_cidr_block` to the `output_map` and `az_subnet_cidr_blocks` as an output.

## why
This is helpful when you want to assign something like the 4th IP in a subnet rather than allowing DHCP to do it's thing.

## references
n/a

