### PR TITLE
Add tags to EIP resource.

### DIFF
--- a/public.tf
+++ b/public.tf
@@ -102,7 +102,7 @@ resource "aws_route_table_association" "public" {
 resource "aws_eip" "public" {
   for_each = local.public_nat_gateway_azs
   vpc      = true
-  tags       = module.public_label.tags
+  tags     = module.public_label.tags
 
   lifecycle {
     create_before_destroy = true

--- a/public.tf
+++ b/public.tf
@@ -102,6 +102,7 @@ resource "aws_route_table_association" "public" {
 resource "aws_eip" "public" {
   for_each = local.public_nat_gateway_azs
   vpc      = true
+  tags       = module.public_label.tags
 
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
## what
The module is adding tags to all the resources except the EIP resource. We should add the same set of tags to that as well.

## why
Adding tags to EIP resources has many advantages.
* Compliance requirement.
* Easy to understand the use by tags.

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip#tags
